### PR TITLE
feat: [FFM-8765]: fix pushpin-worker graph labels

### DIFF
--- a/Feature_Flags/Feature_Flags_QA.json
+++ b/Feature_Flags/Feature_Flags_QA.json
@@ -1324,7 +1324,7 @@
             "uid": "By6zGQL4k"
           },
           "editorMode": "builder",
-          "expr": "sum by(job) (rate(ff_worker_service_sent_messages{namespace=\"${namespace:text}\"}[$__interval]))",
+          "expr": "sum(rate(ff_worker_service_sent_messages{namespace=\"${namespace:text}\"}[$__interval]))",
           "legendFormat": "Sent Messages",
           "range": true,
           "refId": "A"
@@ -1419,7 +1419,7 @@
             "uid": "By6zGQL4k"
           },
           "editorMode": "builder",
-          "expr": "sum by(job) (rate(ff_worker_service_dropped_messages{namespace=\"${namespace:text}\"}[$__interval]))",
+          "expr": "sum(rate(ff_worker_service_dropped_messages{namespace=\"${namespace:text}\"}[$__interval]))",
           "legendFormat": "Dropped Messages",
           "range": true,
           "refId": "A"

--- a/Feature_Flags/Feature_Flags_Services.json
+++ b/Feature_Flags/Feature_Flags_Services.json
@@ -1787,7 +1787,7 @@
             "uid": "P395BF20BBBA74F0A"
           },
           "editorMode": "builder",
-          "expr": "sum by(job) (rate(ff_worker_service_sent_messages{namespace=\"${namespace:text}\"}[$__interval]))",
+          "expr": "sum(rate(ff_worker_service_sent_messages{namespace=\"${namespace:text}\"}[$__interval]))",
           "legendFormat": "Sent Messages",
           "range": true,
           "refId": "A"
@@ -1882,7 +1882,7 @@
             "uid": "P395BF20BBBA74F0A"
           },
           "editorMode": "builder",
-          "expr": "sum by(job) (rate(ff_worker_service_dropped_messages{namespace=\"${namespace:text}\"}[$__interval]))",
+          "expr": "sum(rate(ff_worker_service_dropped_messages{namespace=\"${namespace:text}\"}[$__interval]))",
           "legendFormat": "Dropped Messages",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
**Changes**
For pushpin-worker dropped messages and sent messages graphs, show only the sum of all the messages. 

**Previous**
![Screenshot 2023-10-23 at 10 32 50](https://github.com/harness/harness-dashboards/assets/42169772/ca0690fc-5358-49d4-8270-c4f31491639d)


**New**
![Screenshot 2023-10-23 at 10 25 24](https://github.com/harness/harness-dashboards/assets/42169772/c0a6f1ba-46c3-4512-ad04-8062a370f364)
