### PR TITLE
[fix]: [PL-42157]: Updates Redis and Access control dashboards

### DIFF
--- a/Platform/Access_Control_Entity_Metrics.json
+++ b/Platform/Access_Control_Entity_Metrics.json
@@ -211,6 +211,240 @@
       ],
       "title": "access_control_entity_processing_time_by_action (ms)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${dataSource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "entity_crud [ accessControlService ]"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${dataSource}"
+          },
+          "editorMode": "code",
+          "expr": "avg by(usecaseName, consumergroupName) (redis_streams_consumer_group_behind_by_count{cluster=\"$cluster\", exported_namespace=\"$environment\", consumergroupName=\"$serviceId\"})",
+          "legendFormat": "{{usecaseName}} [ {{consumergroupName}} ]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Consumer Group Behind from Stream",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${dataSource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "entity_crud [ accessControlService ]"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${dataSource}"
+          },
+          "editorMode": "code",
+          "expr": "avg by(usecaseName, consumergroupName) (redis_streams_consumer_group_pending_count{cluster=\"$cluster\", exported_namespace=\"$environment\", consumergroupName=\"$serviceId\"})",
+          "legendFormat": "{{usecaseName}} [ {{consumergroupName}} ]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Consumer Group Pending Count for Stream",
+      "type": "timeseries"
     }
   ],
   "refresh": false,
@@ -295,7 +529,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "accessControlService",
           "value": "accessControlService"
         },

--- a/Platform/Redis-Streams-Monitor.json
+++ b/Platform/Redis-Streams-Monitor.json
@@ -714,17 +714,17 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by(usecaseName) (redis_streams_events_framework_deadletter_queue_size{cluster=\"$cluster\", environment=\"$env\", exported_namespace=\"$namespace\"})",
+          "expr": "avg by(usecaseName, consumergroupName) (redis_streams_consumer_group_behind_by_count{cluster=\"$cluster\", environment=\"$env\", exported_namespace=\"$namespace\"})",
           "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{usecaseName}} [ {{consumergroupName}} ]",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Dead Letter Queue Size (All Streams)",
+      "title": "Consumer Group Behind From Stream (All Streams)",
       "type": "timeseries"
     },
     {
@@ -810,17 +810,17 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by(usecaseName) (redis_streams_events_framework_deadletter_queue_size{cluster=\"$cluster\", usecaseName=\"$usecase\", environment=\"$env\", exported_namespace=\"$namespace\"})",
+          "expr": "avg by(usecaseName, consumergroupName) (redis_streams_consumer_group_behind_by_count{cluster=\"$cluster\", usecaseName=\"$usecase\", environment=\"$env\", exported_namespace=\"$namespace\"})",
           "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{usecaseName}} [ {{consumergroupName}} ]",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Dead Letter Queue Size (Per Stream Selection)",
+      "title": "Consumer Group Behind From Stream (Per Stream Selection)",
       "type": "timeseries"
     },
     {
@@ -913,17 +913,17 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by(consumergroupName) (redis_streams_consumer_group_behind_by_count{cluster=\"$cluster\", environment=\"$env\", exported_namespace=\"$namespace\"})",
+          "expr": "avg by(usecaseName, consumergroupName) (redis_streams_consumer_group_pending_count{cluster=\"$cluster\", environment=\"$env\", exported_namespace=\"$namespace\"})",
           "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{usecaseName}} [ {{consumergroupName}} ]",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Stream Behind Count By Consumer Group Name (All Streams)",
+      "title": "Consumer Group Pending Count (All Streams)",
       "type": "timeseries"
     },
     {
@@ -1009,17 +1009,17 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by(usecaseName) (redis_streams_consumer_group_behind_by_count{cluster=\"$cluster\", usecaseName=\"$usecase\", environment=\"$env\", exported_namespace=\"$namespace\"})",
+          "expr": "avg by(usecaseName, consumergroupName) (redis_streams_consumer_group_pending_count{cluster=\"$cluster\", usecaseName=\"$usecase\", environment=\"$env\", exported_namespace=\"$namespace\"})",
           "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{usecaseName}} [ {{consumergroupName}} ]",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Streams Behind Count By Use Case Name (Per Stream Selection)",
+      "title": "Consumer Group Pending Count (Per Stream Selection)",
       "type": "timeseries"
     },
     {
@@ -1112,17 +1112,17 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by(consumergroupName) (redis_streams_consumer_group_pending_count{cluster=\"$cluster\", environment=\"$env\", exported_namespace=\"$namespace\"})",
+          "expr": "avg by(exported_namespace, usecaseName) (redis_streams_events_framework_deadletter_queue_size{cluster=\"$cluster\", environment=\"$env\", exported_namespace=\"$namespace\"})",
           "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{exported_namespace}}:streams:deadletter_queue:{{usecaseName}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Stream Pending Count By Consumer Group Name (All Streams)",
+      "title": "Dead Letter Queue Size (All Streams)",
       "type": "timeseries"
     },
     {
@@ -1208,17 +1208,17 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by(usecaseName) (redis_streams_consumer_group_pending_count{cluster=\"$cluster\", usecaseName=\"$usecase\", environment=\"$env\", exported_namespace=\"$namespace\"})",
+          "expr": "avg by(exported_namespace, usecaseName) (redis_streams_events_framework_deadletter_queue_size{cluster=\"$cluster\", usecaseName=\"$usecase\", environment=\"$env\", exported_namespace=\"$namespace\"})",
           "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{exported_namespace}}:streams:deadletter_queue:{{usecaseName}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Streams Pending Count By Use Case Name (Per Stream Selection)",
+      "title": "Dead Letter Queue Size (Per Stream Selection)",
       "type": "timeseries"
     }
   ],
@@ -1229,7 +1229,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "QASetup-ManagedPrometheus",
           "value": "QASetup-ManagedPrometheus"
         },
@@ -1303,8 +1303,8 @@
       {
         "current": {
           "selected": true,
-          "text": "full_sync_stream",
-          "value": "full_sync_stream"
+          "text": "entity_crud",
+          "value": "entity_crud"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
- Updates Access control dashboard to include `pending count` and `behind count` for accessControlService consumer groups
- Updates Redis dashboard to show `pending count` and `behind count` for each consumer groups in stream