### PR TITLE
fix: [PL-39166]: Modified the dataSource to match the env value

### DIFF
--- a/Platform/Delegate_admin_Dashboard.json
+++ b/Platform/Delegate_admin_Dashboard.json
@@ -193,7 +193,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "aoIl1JLVk"
+        "uid": "${data_source}"
       },
       "fieldConfig": {
         "defaults": {
@@ -295,7 +295,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "aoIl1JLVk"
+            "uid": "${data_source}"
           },
           "editorMode": "builder",
           "expr": "heartbeat_received{delegateConnectionStatus=\"CONNECTED\", environment=\"$env\", accountId=~\"$account_id\"}",


### PR DESCRIPTION
Active_delegates_dashboard is not giving correct data because of the bad query of the data source. It is by default pointing to qa and not using the env variable based on the cluster when running the query.
Fixed this by modifying the data_source to be equal to env variable.