### PR TITLE
fix: [PL-39166]: Removed ALL from accountId filter in delegate admin dashboard

### DIFF
--- a/Platform/Delegate_admin_Dashboard.json
+++ b/Platform/Delegate_admin_Dashboard.json
@@ -1171,10 +1171,10 @@
         "current": {
           "selected": true,
           "text": [
-            "BdsgiWzwT7CQFeJl9XkQ3A"
+            "wFHXHD0RRQWoO8tIZT5YVw"
           ],
           "value": [
-            "BdsgiWzwT7CQFeJl9XkQ3A"
+            "wFHXHD0RRQWoO8tIZT5YVw"
           ]
         },
         "datasource": {
@@ -1183,7 +1183,7 @@
         },
         "definition": "label_values({__name__=\"heartbeat_received\"}, accountId)",
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": "AcccountID",
         "multi": true,
         "name": "account_id",

--- a/Platform/Delegate_ring.json
+++ b/Platform/Delegate_ring.json
@@ -86,8 +86,8 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
-          "expr": "heartbeat_received{cluster=\"$cluster\", environment=\"$env\"}",
+          "editorMode": "code",
+          "expr": "heartbeat_received{cluster=\"$cluster\", environment=\"$env\", accountId=~\"$account_id\"}",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -263,8 +263,8 @@
             "type": "prometheus",
             "uid": "${dataSource}"
           },
-          "editorMode": "builder",
-          "expr": "heartbeat_received",
+          "editorMode": "code",
+          "expr": "heartbeat_received{cluster=\"$cluster\", environment=\"$env\", accountId=~\"$account_id\"}",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -435,6 +435,37 @@
         "options": [],
         "query": {
           "query": "label_values({__name__=\"heartbeat_received\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "wFHXHD0RRQWoO8tIZT5YVw"
+          ],
+          "value": [
+            "wFHXHD0RRQWoO8tIZT5YVw"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${dataSource}"
+        },
+        "definition": "label_values({__name__=\"heartbeat_received\"}, accountId)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "AcccountID",
+        "multi": true,
+        "name": "account_id",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=\"heartbeat_received\"}, accountId)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
1. Removed the ALL filter for accountId variable in delegate admin dashboard as it is parsing through all the data which is timing out. Checking for a specific accountId is much faster and also makes more sense to filter via a single accountId.
2. Added accountId filter in account-ring dashboard to restrict data to surf through a specific account only.