### PR TITLE
fix: [PL-59970]: Remove Prometheus from system observability dashboard

### DIFF
--- a/System_Health/System_Observability_Dashboard.json
+++ b/System_Health/System_Observability_Dashboard.json
@@ -1792,7 +1792,6 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "/Prometheus/",
         "skipUrlSync": false,
         "type": "datasource"
       },


### PR DESCRIPTION
Remove /Prometheus from system observability dashboard regex

`/Prometheus` regex was added for our SaaS datasource and since this repository is exclusively used by our SMP customers now, we can safely remove it